### PR TITLE
Version 0.5

### DIFF
--- a/ocadmtop_node.sh
+++ b/ocadmtop_node.sh
@@ -3,7 +3,7 @@
 # Owner       # Red Hat - CEE
 # Name        # ocadmtop_node.sh
 # Description # Script to display detailed POD CPU/MEM usage on node
-# @VERSION    # 0.4
+# @VERSION    # 0.5
 ########################################################################
 
 #### Functions
@@ -47,7 +47,6 @@ fct_pod() {
 }
 
 #### MAIN
-VERSION=0.4
 {
 while getopts "cmpL:H:Ad:t:vh" option;do
   case ${option} in


### PR DESCRIPTION
- Using the raw metrics instead of the 'oc adm top pod' command
- Adding an example of the timeout option in the README file