### PR TITLE
Version 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This script will collect the PODs' resources consumption and display them by nod
 ocadmtop_node.sh [-c|-m|-p] [-A|-L <label1>,<label2>,...|-H <host1>,<host2>,...] [-d {0-10}] [-t <TIMEOUT>][-v|-h]
   -c: sort by CPU (default)
   -m: sort by Memory
+  -n: filter on a specific namespace PODs
   -p: sort by namespace/pod
   -L: retrieve node(s) matching all labels
   -H: retrieve node(s) by hostname
@@ -44,4 +45,10 @@ ocadmtop_node.sh - Version:  X.Y
 
 ```bash
 ./ocadmtop_node.sh -H master-1.lab.example.com -d 6
+```
+
+* Displaying a specific namespace by MEM on all nodes
+
+```bash
+./ocadmtop_node.sh -n openshift-monitoring -m
 ```

--- a/ocadmtop_node.sh
+++ b/ocadmtop_node.sh
@@ -3,7 +3,7 @@
 # Owner       # Red Hat - CEE
 # Name        # ocadmtop_node.sh
 # Description # Script to display detailed POD CPU/MEM usage on node
-# @VERSION    # 0.5
+# @VERSION    # 0.6
 ########################################################################
 
 #### Functions
@@ -11,6 +11,7 @@ fct_usage() {
 echo "$(basename $0) [-c|-m|-p] [-A|-L <label1>,<label2>,...|-H <host1>,<host2>,...] [-d {0-10}] [-t <TIMEOUT>][-v|-h]
   -c: sort by CPU (default)
   -m: sort by Memory
+  -n: filter on a specific namespace PODs
   -p: sort by namespace/pod
   -L: retrieve node(s) matching all labels
   -H: retrieve node(s) by hostname
@@ -28,32 +29,49 @@ fct_version() {
   VERSION=$(grep "@VERSION" ${Script} 2>${STD_ERR} | grep -Ev "VERSION=" | cut -d'#' -f3)
   VERSION=${VERSION:-" N/A"}
   echo "$(basename $0) - Version: ${VERSION}"
-  exit 1
+  exit ${RC:-0}
 }
 
 fct_cpu() {
-  echo "CPU|MEM|namespace/pod"
-  for POD in ${PODS}; do echo "${RESOURCES}" | awk -v pod=${POD} '{if($2 == pod){printf "%dm|%dMi|%s\n",$3,$4,$1"/"$2}}'; done | sort -rn
+  echo -e "CPU|MEM|namespace/pod\n---|---|-------------|"
+  for POD_DETAILS in ${POD_LIST}
+  do
+    NAMESPACE=$(echo ${POD_DETAILS} | cut -d'/' -f1)
+    POD=$(echo ${POD_DETAILS} | cut -d'/' -f2)
+    echo "${RESOURCES}" | awk -v pod=${POD} -v namespace=${NAMESPACE} '{if(($1 == namespace) && ($2 == pod)){printf "%dm|%dMi|%s\n",$3,$4,$1"/"$2}}'
+  done | sort -rn
 }
 
 fct_mem() {
-  echo "MEM|CPU|namespace/pod"
-  for POD in ${PODS}; do echo "${RESOURCES}" | awk -v pod=${POD} '{if($2 == pod){printf "%dMi|%dm|%s\n",$4,$3,$1"/"$2}}'; done | sort -rn
+  echo -e "MEM|CPU|namespace/pod\n---|---|-------------|"
+  for POD_DETAILS in ${POD_LIST}
+  do
+    NAMESPACE=$(echo ${POD_DETAILS} | cut -d'/' -f1)
+    POD=$(echo ${POD_DETAILS} | cut -d'/' -f2)
+    echo "${RESOURCES}" | awk -v pod=${POD} -v namespace=${NAMESPACE} '{if(($1 == namespace) && ($2 == pod)){printf "%dMi|%dm|%s\n",$4,$3,$1"/"$2}}'
+  done | sort -rn
 }
 
 fct_pod() {
-  echo "namespace/pod|CPU|MEM"
-  for POD in ${PODS}; do echo "${RESOURCES}" | awk -v pod=${POD} '{if($2 == pod){printf "%s|%dm|%dMi\n",$1"/"$2,$3,$4}}'; done | sort
+  echo -e "namespace/pod|CPU|MEM\n-------------|---|---|"
+  for POD_DETAILS in ${POD_LIST}
+  do
+    NAMESPACE=$(echo ${POD_DETAILS} | cut -d'/' -f1)
+    POD=$(echo ${POD_DETAILS} | cut -d'/' -f2)
+    echo "${RESOURCES}" | awk -v pod=${POD} -v namespace=${NAMESPACE} '{if(($1 == namespace) && ($2 == pod)){printf "%s|%dm|%dMi\n",$1"/"$2,$3,$4}}'
+  done | sort
 }
 
 #### MAIN
 {
-while getopts "cmpL:H:Ad:t:vh" option;do
+OPTNUM=0
+while getopts "cmpn:L:H:Ad:t:vh" option;do
   case ${option} in
     c|m|p) SORT=${option} ;;
-    L) NODE_OPT=L && NODE_ARG=${OPTARG} ;;
-    H) NODES=$(echo ${OPTARG} |sed -e "s!,! !") ;;
-    A) NODE_OPT=A ;;
+    n) NAMESPACE="${OPTARG}" ;;
+    L) NODE_OPT=L && NODE_ARG=${OPTARG} && OPTNUM=$[OPTNUM + 1] ;;
+    H) NODES=$(echo ${OPTARG} |sed -e "s!,! !") && OPTNUM=$[OPTNUM + 1] ;;
+    A) NODE_OPT=A && OPTNUM=$[OPTNUM + 1] ;;
     d) if [[ ${OPTARG} =~ ^[1-9]$ ]] || [[ ${OPTARG} == 10 ]]; then LOGLEVEL="--loglevel ${OPTARG:-6}"; else fct_usage; fi ;;
     t) TIMEOUT=${OPTARG:-"1m"} ;;
     v) fct_version ;;
@@ -63,6 +81,12 @@ done
 TIMEOUT=${TIMEOUT:-"1m"}
 OC="oc --request-timeout=${TIMEOUT}"
 
+if [[ ${OPTNUM} -gt 1 ]]
+then
+  echo "ERR: Too many node filters used (${OPTNUM}). Please limit to a single [-H|-L|-A] option"
+  RC=5 && fct_usage
+fi
+
 if [[ -z $NODES ]]
 then
   case ${NODE_OPT} in
@@ -70,16 +94,30 @@ then
     *)  NODES=$(${OC} get nodes -o name ${LOGLEVEL} | cut -d'/' -f2) ;;
   esac
 fi
+if [[  -z $NODES ]]
+then
+  echo "WARN: Unable to retrieve the list on Nodes. Please review your [-H|-L|-A] option"
+  RC=10 && fct_usage
+fi
 
-RESOURCES=$(${OC} ${LOGLEVEL} get --raw "/apis/metrics.k8s.io/v1beta1/pods" ${LOGLEVEL} | jq -r '.items[] | "\(.metadata | "\(.namespace) \(.name)") \([.containers[].usage.cpu | gsub("m";"") | tonumber] | add) \([.containers[].usage.memory | if(contains("Mi")) then (gsub("Mi";"") | tonumber | . * 1024) elif (contains("Gi")) then (gsub("Gi";"") | tonumber | . * 1024 * 1024) else (gsub("Ki";"") | tonumber) end] | add | . / 1024)"')
+# build the main Variables based on NAMESPACE or NOT (RESOURCES: metrics && ALL_FILTERED_PODS: List of PODs)
+if [[ ! -z ${NAMESPACE} ]]
+then
+  RESOURCES=$(${OC} ${LOGLEVEL} get --raw "/apis/metrics.k8s.io/v1beta1/namespaces/${NAMESPACE}/pods" ${LOGLEVEL} | jq -r '.items[] | "\(.metadata | "\(.namespace) \(.name)") \([.containers[].usage.cpu | gsub("m";"") | tonumber] | add) \([.containers[].usage.memory | if(contains("Mi")) then (gsub("Mi";"") | tonumber | . * 1024) elif (contains("Gi")) then (gsub("Gi";"") | tonumber | . * 1024 * 1024) else (gsub("Ki";"") | tonumber) end] | add | . / 1024)"')
+  ALL_FILTERED_PODS=$(${OC} ${LOGLEVEL} get pod -A -o wide | awk -v namespace=${NAMESPACE} '{if(($4 != "Completed")&&($1 == namespace)){print $1"/"$2" "$(NF-2)}}')
+else
+  RESOURCES=$(${OC} ${LOGLEVEL} get --raw "/apis/metrics.k8s.io/v1beta1/pods" ${LOGLEVEL} | jq -r '.items[] | "\(.metadata | "\(.namespace) \(.name)") \([.containers[].usage.cpu | gsub("m";"") | tonumber] | add) \([.containers[].usage.memory | if(contains("Mi")) then (gsub("Mi";"") | tonumber | . * 1024) elif (contains("Gi")) then (gsub("Gi";"") | tonumber | . * 1024 * 1024) else (gsub("Ki";"") | tonumber) end] | add | . / 1024)"')
+  ALL_FILTERED_PODS=$(${OC} ${LOGLEVEL} get pod -A -o wide | awk '{if($4 != "Completed"){print $1"/"$2" "$(NF-2)}}')
+fi
 for NODE in ${NODES}
 do
   echo -e "\n===== ${NODE} ====="
-  PODS=$(${OC} describe node ${NODE} ${LOGLEVEL} | awk '/Non-terminated Pods:/,/Allocated resources:/{if(($2 != "Pods:") && ($2 != "resources:") && ($2 != "----") && ($2 != "Name")){print $2}}')
+  POD_LIST=$(echo "${ALL_FILTERED_PODS}" | awk -v nodename=${NODE} '{if($2 == nodename){print $1}}')
   case ${SORT} in
     m) fct_mem | column -s'|' -t ;;
     p) fct_pod | column -s'|' -t ;;
     *) fct_cpu | column -s'|' -t ;;
   esac
 done
+echo
 }


### PR DESCRIPTION
- Allowing to filter by namespace (new option: -n)
- Validating that multiple nodes options are not use at the same time
- Caching the 'oc get pod -A' in variable instead of running multiple 'oc describe node'
- Managing multiple RC based on the call of the functions